### PR TITLE
MS Win glob fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -34,10 +34,16 @@ if(argv['node-arg']) {
 function globArgs(argv_) {
     let globbedFiles = []
     for (var i = 0; i < argv_.length; i++) {
-        globbedFiles = globbedFiles.concat(glob.sync(argv_[i]))
-    }
-    if(!globbedFiles) {
-        globbedFiles = argv_
+
+        let globResult = glob.sync(argv_[i])
+        
+        if(globResult.length < 1) {
+            // Glob found nothing. Just add this argument as-is.
+            globbedFiles.push(argv_[i])
+        }
+        else {
+            globbedFiles = globbedFiles.concat(globResult)
+        }
     }
     return globbedFiles
 }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const streams = require('memory-streams')
 const spawn = require('child_process').spawn
 const fs = require('fs')
 const async = require('async-p')
+const glob = require('glob')
 
 let results = {}
 let exitCodes = {}
@@ -29,7 +30,26 @@ if(argv['node-arg']) {
     }
 }
 
-let files = argv._.sort()
+// Use glob to parse any test file args for patterns.
+function globArgs(argv_) {
+    let globbedFiles = []
+
+    if(!Array.isArray(argv_))
+    {
+        globbedFiles = glob.sync(argv_, {cwd: __dirname})
+    }
+    else
+    {
+        for (var i = 0; i < argv_.length; i++) {
+            globbedFiles.concat(glob.sync(argv_[i], { cwd: __dirname }))
+        }
+    }
+
+    return globbedFiles
+}
+module.exports.globArgs = globArgs
+
+let files = globArgs(argv._).sort()
 
 // Start argv.p tests in parallel
 async.eachLimit(files, runTest, argv.p)

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ if(argv['node-arg']) {
 function globArgs(argv_) {
     let globbedFiles = []
     for (var i = 0; i < argv_.length; i++) {
-        globbedFiles = globbedFiles.concat(glob.sync(argv_[i], { cwd: __dirname }))
+        globbedFiles = globbedFiles.concat(glob.sync(argv_[i]))
+    }
+    if(!globbedFiles) {
+        globbedFiles = argv_
     }
     return globbedFiles
 }

--- a/index.js
+++ b/index.js
@@ -33,18 +33,9 @@ if(argv['node-arg']) {
 // Use glob to parse any test file args for patterns.
 function globArgs(argv_) {
     let globbedFiles = []
-
-    if(!Array.isArray(argv_))
-    {
-        globbedFiles = glob.sync(argv_, {cwd: __dirname})
+    for (var i = 0; i < argv_.length; i++) {
+        globbedFiles = globbedFiles.concat(glob.sync(argv_[i], { cwd: __dirname }))
     }
-    else
-    {
-        for (var i = 0; i < argv_.length; i++) {
-            globbedFiles.concat(glob.sync(argv_[i], { cwd: __dirname }))
-        }
-    }
-
     return globbedFiles
 }
 module.exports.globArgs = globArgs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "multi-tape": "index.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tape test/glob-test.js",
     "lint": "./node_modules/.bin/eslint *.js",
     "prepublish": "npm run lint"
   },
@@ -21,12 +21,14 @@
   "license": "MIT",
   "dependencies": {
     "async-p": "^1.1.0",
+    "glob": "^7.1.2",
     "memory-streams": "^0.1.0",
     "minimist": "^1.2.0",
     "tap-parser": "^1.2.2",
     "tee": "^0.2.0"
   },
   "devDependencies": {
-    "eslint": "^1.10.3"
+    "eslint": "^1.10.3",
+    "tape": "^4.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "multi-tape": "index.js"
   },
   "scripts": {
-    "test": "tape test/glob-test.js",
     "lint": "./node_modules/.bin/eslint *.js",
     "prepublish": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "multi-tape": "index.js"
   },
   "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "./node_modules/.bin/eslint *.js",
     "prepublish": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "multi-tape": "index.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tape test/glob-test.js",
     "lint": "./node_modules/.bin/eslint *.js",
     "prepublish": "npm run lint"
   },

--- a/test/glob-test.js
+++ b/test/glob-test.js
@@ -22,3 +22,18 @@ test('Glob parses this project\'s test/*.js', function(t) {
     actual = result[0]
     t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
 })
+
+test('Glob still parses an actual file', function(t) {
+    t.plan(2)
+
+    let arg = ["test/glob-test.js"]
+    let result = multi_tape.globArgs(arg)
+
+    let expected = true
+    let actual = Array.isArray(result)
+    t.equal(Array.isArray(result), true, "Is result array - Expected: " + expected + ", Actual: " + actual)
+
+    expected = "test/" + path.basename(__filename)
+    actual = result[0]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+})

--- a/test/glob-test.js
+++ b/test/glob-test.js
@@ -1,0 +1,24 @@
+
+const test = require('tape')
+const path = require('path')
+const multi_tape = require('../index.js')
+
+test('Glob parses this project\'s test/*.js', function(t) {
+    t.plan(3)
+
+    let arg = "test/*.js"
+    let result = multi_tape.globArgs(arg)
+
+    let expected = true
+    let actual = Array.isArray(result)
+    t.equal(Array.isArray(result), true, "Is result array - Expected: " + expected + ", Actual: " + actual)
+
+    // TODO: There's probably an easy way to count the number of JS files in the test/ directory to make this test future-proof...
+    expected = 1
+    actual = result.length
+    t.equal(actual, expected, "Number of .js files found by glob - Expected: " + expected + ", Actual: " + actual)
+
+    expected = "test/" + path.basename(__filename)
+    actual = result[0]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+})

--- a/test/glob-test.js
+++ b/test/glob-test.js
@@ -6,7 +6,7 @@ const multi_tape = require('../index.js')
 test('Glob parses this project\'s test/*.js', function(t) {
     t.plan(3)
 
-    let arg = "test/*.js"
+    let arg = ["test/*.js"]
     let result = multi_tape.globArgs(arg)
 
     let expected = true

--- a/test/glob-test.js
+++ b/test/glob-test.js
@@ -37,3 +37,40 @@ test('Glob still parses an actual file', function(t) {
     actual = result[0]
     t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
 })
+
+test('A combination of different inputs', function(t) {
+    t.plan(6)
+
+    let arg = ["test/glob-test.js", "test/*.js", "wibble/wibble123.example", "wibble/*.wibblet"]
+
+    // NOTE: Wibble-related paths do not exist. These should still be passed to the test runner, 
+    // in order to comply with the previous implementation.
+
+    let result = multi_tape.globArgs(arg)
+
+    let expected = true
+    let actual = Array.isArray(result)
+    t.equal(Array.isArray(result), true, "Is result array - Expected: " + expected + ", Actual: " + actual)
+    
+    // We're expecting 4 - 1 for each of the "legal" files and 2 for the wibble arguments, which will remain untouched.
+    // TODO: If the number of test files changes, this test will fail...
+    expected = 4
+    actual = result.length;
+    t.equal(actual, expected, "Number of .js files found by glob - Expected: " + expected + ", Actual: " + actual)
+
+    expected = "test/" + path.basename(__filename)
+    actual = result[0]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+    
+    expected = "test/" + path.basename(__filename)
+    actual = result[1]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+
+    expected = "wibble/wibble123.example"
+    actual = result[2]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+
+    expected = "wibble/*.wibblet"
+    actual = result[3]
+    t.equal(actual, expected, "Is result expected filename - Expected: " + expected + "; Actual: " + actual)
+})


### PR DESCRIPTION
@mattiash I think I got there in the end. Had a bit of fun when I was passing the test argument as a `string`, instead of a `string[]`, which led to me building in some unnecessary `if(!Array.isArray...)` stuff.

Plus at one point, I was so focused on _glob_ that I forgot that a non-glob pattern input (e.g. `multi-tape test/example.js`) would simply be ignored...

I added a few tests to prove it will still work with multiple files and multiple combinations of files with different glob/non-glob patterns... But I thought I'd share my progress with you because I might not be able to look at this again for a few days.

I have also tested this against my original issue and it seems to work fine - no more errors for #1 ! 

Full disclosure: This is my *first ever* GitHub collaboration, so please treat my work with caution... Any feedback is greatly appreciated.