### PR TITLE
Splitting up buffered console output

### DIFF
--- a/lib/run-test.ts
+++ b/lib/run-test.ts
@@ -46,9 +46,14 @@ export async function runTest(
     const result = await parsed
 
     if (!logConsole) {
-        console.log(
-            (output as streams.WritableStreamBuffer).getContentsAsString('utf8')
+        const lines = (output as streams.WritableStreamBuffer).getContentsAsString(
+            'utf8'
         )
+        if (lines) {
+            for (const line of lines.split('\n')) {
+                console.log(line)
+            }
+        }
     }
 
     if (signal) {


### PR DESCRIPTION
This is to avoid buffer overflows when having tests that have
large console output. In some environments (node.js < 13.3 in
Docker) large writes terminate the Node.js process with:

write /dev/stdout: resource temporarily unavailable